### PR TITLE
Added full lifecycle management and certification system for medical devices

### DIFF
--- a/contracts/STX-MediProof.clar
+++ b/contracts/STX-MediProof.clar
@@ -124,3 +124,181 @@
   (is-eq sender (var-get contract-owner))
 )
 
+
+
+;; Check if sender is approved regulatory body
+(define-private (is-regulatory-body (authority principal) (cert-type uint))
+  (default-to 
+    false
+    (get approved (map-get? regulatory-bodies {authority: authority, cert-type: cert-type}))
+  )
+)
+
+;; Register a new device
+(define-public (register-device (device-id uint) (initial-status uint))
+  (begin
+    (asserts! (is-valid-device-id device-id) ERR_INVALID_DEVICE)
+    (asserts! (is-valid-status initial-status) ERR_INVALID_STATUS)
+    (asserts! (or (is-contract-owner tx-sender) (is-eq initial-status DEVICE_STATUS_MANUFACTURED)) ERR_UNAUTHORIZED)
+
+    (map-set device-details 
+      {device-id: device-id}
+      {
+        owner: tx-sender,
+        current-status: initial-status,
+        history: (list {status: initial-status, timestamp: (get-current-timestamp)})
+      }
+    )
+    (ok true)
+  )
+)
+
+;; Update device status
+(define-public (update-device-status (device-id uint) (new-status uint))
+  (let 
+    (
+      (device (unwrap! (map-get? device-details {device-id: device-id}) ERR_INVALID_DEVICE))
+    )
+    (asserts! (is-valid-device-id device-id) ERR_INVALID_DEVICE)
+    (asserts! (is-valid-status new-status) ERR_INVALID_STATUS)
+    (asserts! 
+      (or 
+        (is-contract-owner tx-sender)
+        (is-eq (get owner device) tx-sender)
+      ) 
+      ERR_UNAUTHORIZED
+    )
+
+    (map-set device-details 
+      {device-id: device-id}
+      (merge device 
+        {
+          current-status: new-status,
+          history: (unwrap-panic 
+            (as-max-len? 
+              (append (get history device) {status: new-status, timestamp: (get-current-timestamp)}) 
+              u10
+            )
+          )
+        }
+      )
+    )
+    (ok true)
+  )
+)
+
+;; Add regulatory body with additional validation
+(define-public (add-regulatory-body (authority principal) (cert-type uint))
+  (begin
+    (asserts! (is-contract-owner tx-sender) ERR_UNAUTHORIZED)
+    (asserts! (is-valid-certification-type cert-type) ERR_INVALID_CERTIFICATION)
+    (asserts! (is-valid-authority authority) ERR_UNAUTHORIZED)
+
+    ;; After validation, we can safely use the authority
+    (map-set regulatory-bodies
+      {authority: authority, cert-type: cert-type}
+      {approved: true}
+    )
+    (ok true)
+  )
+)
+
+;; Add certification to device
+(define-public (add-certification (device-id uint) (cert-type uint))
+  (begin
+    (asserts! (is-valid-device-id device-id) ERR_INVALID_DEVICE)
+    (asserts! (is-valid-certification-type cert-type) ERR_INVALID_CERTIFICATION)
+    (asserts! (is-regulatory-body tx-sender cert-type) ERR_UNAUTHORIZED)
+
+    (asserts! 
+      (is-none 
+        (map-get? device-certifications {device-id: device-id, cert-type: cert-type})
+      )
+      ERR_CERTIFICATION_EXISTS
+    )
+
+    (let
+      ((validated-device-id device-id)
+       (validated-cert-type cert-type))
+      (map-set device-certifications
+        {device-id: validated-device-id, cert-type: validated-cert-type}
+        {
+          issuer: tx-sender,
+          timestamp: (get-current-timestamp),
+          valid: true
+        }
+      )
+      (ok true)
+    )
+  )
+)
+
+;; Verify device certification
+(define-read-only (verify-certification (device-id uint) (cert-type uint))
+  (let
+    (
+      (certification (unwrap! 
+        (map-get? device-certifications {device-id: device-id, cert-type: cert-type})
+        ERR_INVALID_CERTIFICATION
+      ))
+    )
+    (ok (get valid certification))
+  )
+)
+
+;; Revoke certification
+(define-public (revoke-certification (device-id uint) (cert-type uint))
+  (begin
+    (asserts! (is-valid-device-id device-id) ERR_INVALID_DEVICE)
+    (asserts! (is-valid-certification-type cert-type) ERR_INVALID_CERTIFICATION)
+
+    (let
+      (
+        (certification (unwrap! 
+          (map-get? device-certifications {device-id: device-id, cert-type: cert-type})
+          ERR_INVALID_CERTIFICATION
+        ))
+        (validated-device-id device-id)
+        (validated-cert-type cert-type)
+      )
+      (asserts! 
+        (or
+          (is-contract-owner tx-sender)
+          (is-eq (get issuer certification) tx-sender)
+        )
+        ERR_UNAUTHORIZED
+      )
+
+      (map-set device-certifications
+        {device-id: validated-device-id, cert-type: validated-cert-type}
+        (merge certification {valid: false})
+      )
+      (ok true)
+    )
+  )
+)
+
+;; Get device history
+(define-read-only (get-device-history (device-id uint))
+  (let 
+    (
+      (device (unwrap! (map-get? device-details {device-id: device-id}) ERR_INVALID_DEVICE))
+    )
+    (ok (get history device))
+  )
+)
+
+;; Get current device status
+(define-read-only (get-device-status (device-id uint))
+  (let 
+    (
+      (device (unwrap! (map-get? device-details {device-id: device-id}) ERR_INVALID_DEVICE))
+    )
+    (ok (get current-status device))
+  )
+)
+
+;; Get certification details
+(define-read-only (get-certification-details (device-id uint) (cert-type uint))
+  (ok (map-get? device-certifications {device-id: device-id, cert-type: cert-type}))
+)


### PR DESCRIPTION
#### **Title:**  
Added Smart Contract for Medical Device Lifecycle Management and Certification Governance

---

#### **Summary:**  
This pull request introduces the complete implementation of a Clarity-based smart contract for managing the registration, lifecycle updates, and regulatory certifications of medical devices. It enables secure, transparent tracking of device states and the issuance and revocation of certifications by approved authorities, with historical data and access control.

---

#### **Key Features:**

---

### 🏥 Medical Device Lifecycle Management

#### `register-device (device-id, initial-status)`
- Allows a new device to be registered with an initial lifecycle status.
- Ensures only the contract owner or public users registering with `MANUFACTURED` status can perform the operation.
- Saves device metadata and initializes status history with a synthetic timestamp.

#### `update-device-status (device-id, new-status)`
- Enables the contract owner or device owner to update the current status.
- Maintains a chronological history (max 10 records) of status changes, with synthetic timestamps.
- Validates status and device ID before modification.

---

### 📜 Certification Governance

#### Certification Types Supported:
- FDA (`u1`)
- CE (`u2`)
- ISO (`u3`)
- SAFETY (`u4`)

#### `add-regulatory-body (authority, cert-type)`
- Allows the contract owner to approve a principal as an issuing authority for a specific certification type.
- Ensures proper validation of authority and certification type.

#### `add-certification (device-id, cert-type)`
- Allows an approved regulatory body to certify a device with a particular certification type.
- Rejects duplicate certifications.
- Logs the issuer, timestamp, and sets the certification as valid.

#### `revoke-certification (device-id, cert-type)`
- Enables the original issuer or contract owner to revoke a certification.
- Updates the certification's validity flag without deleting data.

#### `verify-certification (device-id, cert-type)`
- Public read-only function to check if a certification exists and is still valid.

#### `get-certification-details (device-id, cert-type)`
- Returns full metadata for a device’s certification, including issuer, timestamp, and validity.

---

### 🔍 Read-Only Queries

- `get-device-history (device-id)`: Retrieves up to 10 previous status updates with timestamps.
- `get-device-status (device-id)`: Returns the current status of the device.

---

### 🛡️ Validation and Access Control

- Device ID validation (ensures bounded numeric range).
- Status value and certification type validation.
- Authority validation to prevent self-authorization or malicious actors.
- Role-based access enforced using contract ownership checks.

---